### PR TITLE
Add requirements file

### DIFF
--- a/flask-api/requirements.txt
+++ b/flask-api/requirements.txt
@@ -1,0 +1,5 @@
+Flask
+Flask-Cors
+Flask-SQLAlchemy
+PyJWT
+requests


### PR DESCRIPTION
## Summary
- list dependencies needed to run the Flask API

## Testing
- `python3 -m pip install -r flask-api/requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_683f826b14e883288ac9c3fef4e1876a